### PR TITLE
Fix GitHub Pages deployment path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "heart-monitor-demo",
+  "name": "heart-monitor-app",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "heart-monitor-demo",
+      "name": "heart-monitor-app",
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "heart-monitor-demo",
+  "name": "heart-monitor-app",
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://ceis-kamiya.github.io/heart-monitor-demo",
+  "homepage": "https://ceis-kamiya.github.io/heart-monitor-app",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- correct package name
- sync homepage URL with Vite base path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840ecc976fc8328acbf5e48c5d6befe