### PR TITLE
Fix checkout typo in docs

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -13,7 +13,7 @@ git reset --hard origin/master
 git branch
 
 ## ブランチの移動
-git chechout ブランチ名（またはコミットのハッシュ）
+git checkout ブランチ名（またはコミットのハッシュ）
 
 ## GitHubからのクローン
 git clone https://github.com/ユーザー名/リポジトリ名.git

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -79,7 +79,7 @@ git reset --hard origin/master
 git branch
 
 ## ブランチの移動
-git chechout ブランチ名（またはコミットのハッシュ）
+git checkout ブランチ名（またはコミットのハッシュ）
 
 ## GitHubからのクローン
 git clone https://github.com/ユーザー名/リポジトリ名.git


### PR DESCRIPTION
## Summary
- fix `git chechout` typo in `memo.md`
- keep `repomix-output.xml` in sync

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840f0e6d97c8328a3190c1649a48f05